### PR TITLE
stage 2 features not working

### DIFF
--- a/src/client/modules/babelCode/mycode.js
+++ b/src/client/modules/babelCode/mycode.js
@@ -1,0 +1,8 @@
+const doStuff = ()=>{
+  const obj1 = {a : 1};
+  const obj2 = {...obj1, b: 2};
+  return "ok";
+};
+
+
+export default doStuff;

--- a/src/client/modules/babelCode/tests/doStuff.js
+++ b/src/client/modules/babelCode/tests/doStuff.js
@@ -1,0 +1,10 @@
+import { expect } from 'chai';
+import doStuff from '../mycode';
+
+describe('doStuff', ()=>{
+  it("works",()=>{
+    expect(doStuff()).to.equal("ok");
+  });
+});
+
+

--- a/wallaby.js
+++ b/wallaby.js
@@ -6,11 +6,13 @@ module.exports = function (wallaby) {
       "src/client/modules/**/actions/*.ts",
       "src/client/modules/**/containers/*.ts",
       "src/client/modules/**/libs/*.ts",
-      "src/typings/**/*.d.ts"
+      "src/typings/**/*.d.ts",
+      "src/client/modules/**/babelCode/*.js"
     ],
     tests: [
       "src/client/**/tests/*.ts",
-      "src/client/**/tests/*.tsx"
+      "src/client/**/tests/*.tsx",
+      "src/client/**/tests/*.js"
     ],
     compilers: {
       "**/*.ts*": wallaby.compilers.typeScript({module: 'es6'})


### PR DESCRIPTION
Here i'm demonstrating the use of ES7 code with babel "stage 2" features.
The babel stage 2 preprocessing step seems to not work correctly, since an error is reported on the object spread operator.
